### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/SonicDev100/d80fe773-2b6c-4016-8b13-97f2e2249090/cb4a4811-cad4-48e5-91b5-70629c06198c/_apis/work/boardbadge/e6eea3a5-e2ad-4152-88c8-bf9dac20dbf9)](https://dev.azure.com/SonicDev100/d80fe773-2b6c-4016-8b13-97f2e2249090/_boards/board/t/cb4a4811-cad4-48e5-91b5-70629c06198c/Microsoft.RequirementCategory)
 
 Ansible Examples
 ----------------


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2004](https://dev.azure.com/SonicDev100/d80fe773-2b6c-4016-8b13-97f2e2249090/_workitems/edit/2004). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.